### PR TITLE
Fix issues with Disconnect method in WatsonTcpClient

### DIFF
--- a/src/WatsonTcp/WatsonTcpClient.cs
+++ b/src/WatsonTcp/WatsonTcpClient.cs
@@ -492,6 +492,7 @@
                 {
                     _TokenSource.Cancel();
                     _TokenSource.Dispose();
+                    _Token = default(CancellationToken);
                 }
             }
              
@@ -510,12 +511,12 @@
                 _Client.Close();
             }
 
-            while (_DataReceiver?.Status == TaskStatus.Running)
+            while (_DataReceiver?.IsCompleted == false)
             {
                 Task.Delay(10).Wait();
             }
 
-            while (_IdleServerMonitor?.Status == TaskStatus.Running)
+            while (_IdleServerMonitor?.IsCompleted == false)
             {
                 Task.Delay(10).Wait();
             }


### PR DESCRIPTION
1. Reset _Token upon disconnect. This addresses an issue where calling connect after disconnect would result in a TaskCanceledException being thrown.

This was observed when running the Test.Reconnect sample.

2. Check IsCompleted instead of Status for the _DataReceiver and _IdleServerMonitor tasks. This addresses an issue where the task Status may be WaitingForActivation instead of Running.

After fixing the first issue, I encountered a problem in the Test.Reconnect sample where calling Disconnect would result in an InvalidOperationException. This was due to the _DataReceiver task setting Connected to false. It turns out that the Status of the _DataReceiver task was WaitingForActivation when Disconnect was called, so the task was still active when Connect was called a second time.