### PR TITLE
Fix listening on all IP addresses little bug

### DIFF
--- a/src/WatsonTcp/WatsonTcpServer.cs
+++ b/src/WatsonTcp/WatsonTcpServer.cs
@@ -207,8 +207,9 @@
             if (listenerPort < 1) throw new ArgumentOutOfRangeException(nameof(listenerPort));
 
             _Mode = Mode.Tcp; 
-             
-            if (String.IsNullOrEmpty(listenerIp))
+
+             // According to the https://github.com/dotnet/WatsonTcp?tab=readme-ov-file#local-vs-external-connections
+            if (string.IsNullOrEmpty(listenerIp) || listenerIp.Equals("*") || listenerIp.Equals("+") || listenerIp.Equals("0.0.0.0"))
             {
                 _ListenerIpAddress = IPAddress.Any;
                 _ListenerIp = _ListenerIpAddress.ToString();


### PR DESCRIPTION
According to the [https://github.com/dotnet/WatsonTcp?tab=readme-ov-file#local-vs-external-connections](https://github.com/dotnet/WatsonTcp?tab=readme-ov-file#local-vs-external-connections) the '**if**' statement should be changed 👍